### PR TITLE
Change :: to : for ::force-copy?

### DIFF
--- a/src/fortran-call.lisp
+++ b/src/fortran-call.lisp
@@ -260,7 +260,7 @@ PARAMETERS is used to specify information that is applicable for all arguments (
 (defmacro &array-in/out ((&key input
                                ((:type input-type))
                                ((:transpose? input-transpose?))
-                               ((::force-copy? input-force-copy?) nil
+                               ((:force-copy? input-force-copy?) nil
                                 input-force-copy?-specified?))
                          (&key (output input)
                                ((:dimensions output-dimensions))


### PR DESCRIPTION
The :: prefix looks like a typo that takes advantage of an sbcl undefined behavior that parses ::force-copy? as the keyword symbol :force-copy?
This makes the code non-portable to a CL implementation that doesn't share the same undefined behavior.